### PR TITLE
Fix zone variable reference and grid generation

### DIFF
--- a/argus/main.py
+++ b/argus/main.py
@@ -19,6 +19,6 @@ firms_data = fetch_firms_data(selected_zone)
 # Display raw data
 if not firms_data.empty and "latitude" in firms_data.columns and "longitude" in firms_data.columns:
     st.write("### FIRMS Heat Anomalies", firms_data.head(10))
-    visualize_anomalies(firms_data, zone)
+    visualize_anomalies(firms_data, selected_zone)
 else:
     st.warning("⚠️ No valid FIRMS data found for this zone. Try a different area or broader time window.")

--- a/argus/scanner/live_ping.py
+++ b/argus/scanner/live_ping.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from visualize.grid_map import build_map  # NEW: for visual integration
 
 def scan_tiles(step=5, delay=1.5, days=3, source="VIIRS_SNPP_NRT",  lat_range=(-90, 90), lon_range=(-180, 180)):
-    tiles = generate_grid(step=step)
+    tiles = generate_grid(step=step, lat_range=lat_range, lon_range=lon_range)
     scan_log = []
 
     print(f"🔍 Starting live scan with {len(tiles)} tiles...\n")


### PR DESCRIPTION
## Summary
- reference `selected_zone` when visualizing anomalies
- propagate latitude/longitude ranges to grid generation

## Testing
- `python -m compileall -q argus`

------
https://chatgpt.com/codex/tasks/task_e_68772b6ce80c8326b9270670de0578c4