### PR TITLE
Add satellite fetch utility and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ streamlit run argus/app.py
 
 Scan results will be saved to `output/grid_map.html`.
 
+## Satellite Image Classification
+
+When a heat anomaly is detected you can fetch a higher resolution
+satellite image of the affected tile using the helper in
+`argus/utils/satellite.py`. The downloaded image can then be passed to
+`classify_thermal_anomaly` for a very lightweight classification step.
+
 ## Testing
 
 Run unit tests with `pytest`:

--- a/argus/utils/satellite.py
+++ b/argus/utils/satellite.py
@@ -1,0 +1,49 @@
+import os
+import urllib.request
+import logging
+
+NASA_API_KEY = os.getenv("NASA_API_KEY", "DEMO_KEY")
+logger = logging.getLogger(__name__)
+
+
+def fetch_satellite_image(lat, lon, *, dim=0.1, date=None, output="data/satellite.png"):
+    """Download a satellite image for the given coordinates.
+
+    Parameters
+    ----------
+    lat, lon : float
+        Center point of the desired image.
+    dim : float, optional
+        Width and height of the image in degrees.
+    date : str, optional
+        Date string (YYYY-MM-DD). If omitted, the most recent image is used.
+    output : str, optional
+        Path where the image file will be written.
+
+    Returns
+    -------
+    str
+        The path to the saved image file.
+    """
+    params = f"lat={lat}&lon={lon}&dim={dim}&api_key={NASA_API_KEY}"
+    if date:
+        params += f"&date={date}"
+    url = f"https://api.nasa.gov/planetary/earth/imagery?{params}"
+    logger.info("Fetching satellite image from %s", url)
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read()
+    os.makedirs(os.path.dirname(output), exist_ok=True)
+    with open(output, "wb") as f:
+        f.write(data)
+    return output
+
+
+def classify_thermal_anomaly(image_path, *, threshold=50000):
+    """Very basic classification based on file size.
+
+    The function returns ``"hot spot"`` if the file size exceeds ``threshold``
+    bytes, otherwise ``"no anomaly"``. This placeholder approach avoids heavy
+    dependencies while providing a simple example pipeline.
+    """
+    size = os.path.getsize(image_path)
+    return "hot spot" if size > threshold else "no anomaly"

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -1,0 +1,26 @@
+from argus.utils.satellite import fetch_satellite_image, classify_thermal_anomaly
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+
+def test_fetch_satellite_image(tmp_path):
+    dummy_data = b"imagebytes"
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = dummy_data
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        out_file = tmp_path / "img.png"
+        path = fetch_satellite_image(0, 0, output=str(out_file))
+        assert Path(path).exists()
+        assert out_file.read_bytes() == dummy_data
+
+
+def test_classify_thermal_anomaly(tmp_path):
+    small = tmp_path / "small.png"
+    small.write_bytes(b"x" * 100)
+    assert classify_thermal_anomaly(str(small), threshold=200) == "no anomaly"
+
+    large = tmp_path / "large.png"
+    large.write_bytes(b"x" * 1000)
+    assert classify_thermal_anomaly(str(large), threshold=200) == "hot spot"


### PR DESCRIPTION
## Summary
- add new utility `satellite.py` for downloading imagery and simple anomaly classification
- document satellite classification step in README
- test the new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775e9ec8a8832684cfde5f2773c0de